### PR TITLE
Fixed undefined variables error

### DIFF
--- a/edit_form.php
+++ b/edit_form.php
@@ -92,8 +92,8 @@ class block_anderspink_edit_form extends block_edit_form {
         $mform->setType('config_title', PARAM_TEXT);
 
         $radioarray = array();
-        $radioarray[] = $mform->createElement('radio', 'config_source', '', get_string('showbriefing', 'block_anderspink'), 'briefing', $attributes);
-        $radioarray[] = $mform->createElement('radio', 'config_source', '', get_string('showsavedboard', 'block_anderspink'), 'board', $attributes);
+        $radioarray[] = $mform->createElement('radio', 'config_source', '', get_string('showbriefing', 'block_anderspink'), 'briefing');
+        $radioarray[] = $mform->createElement('radio', 'config_source', '', get_string('showsavedboard', 'block_anderspink'), 'board');
         $mform->addGroup($radioarray, 'radioar', '', array(' '), false);
         $mform->setDefault('config_source', 'briefing');
 


### PR DESCRIPTION
The block was giving developer warnings due to the undefined $attributes variable on the block editing page.
